### PR TITLE
Add default project names

### DIFF
--- a/projects/models.py
+++ b/projects/models.py
@@ -87,7 +87,7 @@ class Project(models.Model):
     embed_link = models.CharField(max_length=400, blank = True, null=True,)
     semester = models.CharField(max_length=4, choices=Semester.choices)
     project_category = models.CharField(max_length=200, blank=True, null=True)
-    project_name = models.CharField(max_length=200, blank=True, null=True)
+    project_name = models.CharField(max_length=200, blank=True, default='PROJECT HAS NO NAME')
     student_num = models.IntegerField(default=0)
     project_workflow = models.CharField(max_length=1000, blank=True)
     dataset = models.CharField(max_length=50, blank=True)


### PR DESCRIPTION
NONE project names causes errors when displaying in sorted form (comparision cannot be done between string and None).